### PR TITLE
about Sodemann et al. moisture uptake method

### DIFF
--- a/pysplit/traj.py
+++ b/pysplit/traj.py
@@ -439,11 +439,12 @@ class Trajectory(HyPath):
 
                 if self.uptake.loc[w, 'dq_initial'] < precipitation:
                     # Adjust previous fractions
-                    self.uptake.loc[is_below, 'dq'] = (
+                    if self.uptake.loc[w, 'Timestep'] != 0:
+                      self.uptake.loc[is_below, 'dq'] = (
                         self.uptake.loc[is_below, 'below'] *
                         self.uptake.loc[w, 'q'])
 
-                    self.uptake.loc[is_above, 'dq'] = (
+                      self.uptake.loc[is_above, 'dq'] = (
                         self.uptake.loc[is_above, 'above'] *
                         self.uptake.loc[w, 'q'])
 


### PR DESCRIPTION
In Sodemann et al. (2008), they did not discount previous dq at h = 0 (see table 1), but in the current code it did get discounted. If the current code was applied to data shown in table 1 of that publication, then dq values at -18h, -36h, and -48h, would be discounted by precipitation at 0h. Then the dq values will change from 0.3, 1.380, 0.736 to 0.242, 1.115, 0.594. This commit will keep dq discounting procedure strictly as same as Sodemann et al. (2008).

However, the reason why Sodemann did not include precipitation discounting for dq at 0h is unknown. Discounting or not at 0h is not important, and does make too much difference in results.